### PR TITLE
Remove dangling event listeners to avoid memory leaks

### DIFF
--- a/components/molecules/Card/BlogCard/index.tsx
+++ b/components/molecules/Card/BlogCard/index.tsx
@@ -28,14 +28,21 @@ const BlogCard = ({
         height: container.current?.clientWidth / 1.5,
       })
     }
-    window.addEventListener('resize', () => {
+
+    const resizeListener = () => {
       if (container.current?.clientWidth !== undefined) {
         setImageSize({
           width: container.current?.clientWidth,
           height: container.current?.clientWidth / 1.5,
         })
       }
-    })
+    };
+
+    window.addEventListener('resize', resizeListener)
+
+    return () => {
+      window.removeEventListener('resize', resizeListener);
+    };
   }, [])
   return (
     <div className="w-full space-y-6" ref={container}>

--- a/components/molecules/Card/TeamCard/index.tsx
+++ b/components/molecules/Card/TeamCard/index.tsx
@@ -16,14 +16,21 @@ const TeamCard = ({ imageSrc, job, name }: TeamCardProps) => {
         height: container.current?.clientWidth * 1.1,
       })
     }
-    window.addEventListener('resize', () => {
+
+    const resizeListener = () => {
       if (container.current?.clientWidth !== undefined) {
         setImageSize({
           width: container.current?.clientWidth,
           height: container.current?.clientWidth * 1.085,
         })
       }
-    })
+    };
+
+    window.addEventListener('resize', resizeListener)
+
+    return () => {
+      window.removeEventListener('resize', resizeListener);
+    };
   }, [container])
   return (
     <div className="w-full rounded-md overflow-hidden" ref={container}>

--- a/components/organisms/NavBar/index.tsx
+++ b/components/organisms/NavBar/index.tsx
@@ -13,13 +13,19 @@ const NavBar = () => {
   const browserName = useGetBrowserName()
   const isMobile = useMobileDeviceDetection()
   useEffect(() => {
-    window.addEventListener('scroll', () => {
+    const scrollListener = () => {
       if (window.scrollY > 150) {
         setIsScrolled(true)
       } else {
         setIsScrolled(false)
       }
-    })
+    };
+
+    window.addEventListener('scroll', scrollListener)
+
+    return () => {
+      window.removeEventListener('scroll', scrollListener);
+    };
   }, [])
   useEffect(() => {
     if (isOpen) {

--- a/hooks/useGetBrowserName.tsx
+++ b/hooks/useGetBrowserName.tsx
@@ -5,9 +5,12 @@ const useGetBrowserName = () => {
   const [browserName, setBrowserName] = useState('Chrome')
   useEffect(() => {
     setBrowserName(`${UAParser.UAParser().browser.name}`)
-    window.addEventListener('resize', () =>
-      setBrowserName(`${UAParser.UAParser().browser.name}`)
-    )
+    const updateBrowserName = () => setBrowserName(`${UAParser.UAParser().browser.name}`);
+    window.addEventListener('resize', updateBrowserName)
+
+    return () => {
+      window.removeEventListener('resize', updateBrowserName);
+    };
   })
   return browserName
 }

--- a/hooks/useMobileDetection.tsx
+++ b/hooks/useMobileDetection.tsx
@@ -4,8 +4,16 @@ const useMobileDeviceDetection: () => boolean = () => {
   const [isMobile, setIsMobile] = useState<boolean>(false)
   useEffect(() => {
     deviceTypeHandler()
-    window.addEventListener('resize', () => deviceTypeHandler())
-    window.addEventListener('scroll', () => deviceTypeHandler())
+    const resizeListener = () => deviceTypeHandler();
+    window.addEventListener('resize', resizeListener)
+
+    const scrollListener = () => deviceTypeHandler();
+    window.addEventListener('scroll', scrollListener)
+
+    return () => {
+      window.removeEventListener('resize', resizeListener);
+      window.removeEventListener('scroll', scrollListener);
+    };
   }, [])
 
   const deviceTypeHandler: () => void = () => {

--- a/pages/blog/detail/index.tsx
+++ b/pages/blog/detail/index.tsx
@@ -38,7 +38,8 @@ const BlogDetail = () => {
         height: forestContainer.current?.clientWidth / 1.9,
       })
     }
-    window.addEventListener('resize', () => {
+
+    const resizeListener = () => {
       if (thumbnailContainer.current?.clientWidth !== undefined) {
         setThumbnailSize({
           width: thumbnailContainer.current?.clientWidth,
@@ -51,7 +52,13 @@ const BlogDetail = () => {
           height: forestContainer.current?.clientWidth / 1.9,
         })
       }
-    })
+    };
+
+    window.addEventListener('resize', resizeListener)
+
+    return () => {
+      window.removeEventListener('resize', resizeListener);
+    };
   }, [thumbnailContainer, forestContainer])
   const blogListData: BlogCardProps[] = [
     {


### PR DESCRIPTION
Hello 👋 
As part of our project, we are using Facebook's new Memlab tool to detect memory leaks in SPA applications. 
While running the tool and analyzing the code of Collosal, we saw that it does a very good job of ensuring that all async operations are cancelled when the component unmounts. However, as per Memlab execution results, we found that the removal of event listeners is forgotten at certain places and is causing the memory to leak (screenshots below).

[before]
<img width="774" alt="Screen Shot 2023-01-24 at 12 41 19 AM" src="https://user-images.githubusercontent.com/56495631/214095827-a3a34642-0c5b-4f02-95b3-78855212b839.png">
<img width="643" alt="Screen Shot 2023-01-24 at 12 41 30 AM" src="https://user-images.githubusercontent.com/56495631/214095865-1824bede-af89-4545-92ff-d2214e55089d.png">
<br />
Hence we added the fix by removing the event listeners and you can see the heap size and # of leaks reducing noticeably:
 <br />
<img width="763" alt="Screen Shot 2023-01-24 at 1 04 18 AM" src="https://user-images.githubusercontent.com/56495631/214095948-b3db1f03-7498-47b0-9d5b-58605cd389a4.png">
<img width="525" alt="Screen Shot 2023-01-24 at 12 48 47 AM" src="https://user-images.githubusercontent.com/56495631/214095968-3b7b9acc-dbfd-4a7b-a9eb-3d2ef9e1ef5e.png">


You can test this and other potential leak sources, if you like, by running [Memlab](https://facebook.github.io/memlab/) with a scenario file covering the maximum # of use cases.
Following is a sample of the scenario file we used (it needs to be a .js file but attaching here in txt form):
[collosal-test-scenario.txt](https://github.com/iceboy1406/collosal/files/10481754/collosal-test-scenario.txt)

Note that some other reported leaks originate from React's internal objects, hence ignored.